### PR TITLE
make extension work with groovy 4.x and spock2.2-groovy-4.0

### DIFF
--- a/src/main/groovy/be/janbols/spock/extension/dbunit/support/DbUnitInterceptor.groovy
+++ b/src/main/groovy/be/janbols/spock/extension/dbunit/support/DbUnitInterceptor.groovy
@@ -72,7 +72,7 @@ class DbUnitInterceptor extends AbstractMethodInterceptor {
             @Override
             IDatabaseConnection getConnection() throws Exception {
                 if (!currentConnection || currentConnection.connection.isClosed()) {
-                    currentConnection = super.connection
+                    currentConnection = super.getConnection()
                 }
                 return currentConnection
             }


### PR DESCRIPTION
```
Caused by: groovy.lang.MissingMethodException: No signature of method: org.dbunit.DataSourceDatabaseTester.getConnection() is applicable for argument types: () values: []
Possible solutions: getConnection()
	at be.janbols.spock.extension.dbunit.support.DbUnitInterceptor$1.getConnection(DbUnitInterceptor.groovy:72)
	at au.com.foxtel.registry.external.DataSourceForTests$_closure2.doCall(DataSourceForTests.groovy:84)
	at be.janbols.spock.extension.dbunit.support.DbUnitInterceptor.configureTester(DbUnitInterceptor.groovy:95)
	... 52 more
	```